### PR TITLE
Move SSL functions to child process to prevent parent process blocking

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,8 +1,10 @@
 CC = clang
-CFLAGS = -Wall -Wextra -pedantic
+CFLAGS += -Wall -Wextra -pedantic
 # For Apple Silicon (M1/M2) Macs:
 INCLUDES = -I/opt/homebrew/opt/openssl/include
 LDFLAGS = -L/opt/homebrew/opt/openssl/lib -lssl -lcrypto
 
+-include makefile.local
+
 build:
-	$(CC) $(CFLAGS) $(INCLUDES) src/server.c src/utils.c -o server $(LDFLAGS)
+	$(CC) $(CFLAGS) $(INCLUDES) src/server.c src/debug.c src/utils.c -o server $(LDFLAGS)

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,0 +1,24 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <time.h>
+#include <stdarg.h>
+#include <sys/time.h>
+
+void debug_printf(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+
+    pid_t pid = getpid();
+
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    time_t now = tv.tv_sec;
+    struct tm *t = localtime(&now);
+    char time_str[100];
+    snprintf(time_str, sizeof(time_str), "%02d:%02d:%02d.%03ld", t->tm_hour, t->tm_min, t->tm_sec, tv.tv_usec / 1000);
+
+    printf("[%s] [PID: %d] ", time_str, pid);
+    vprintf(format, args);
+
+    va_end(args);
+}

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,6 @@
+#ifdef DEBUG
+#define DEBUG_PRINT(...) debug_printf(__VA_ARGS__)
+void debug_printf(const char *format, ...);
+#else
+#define DEBUG_PRINT(...) // Do nothing
+#endif


### PR DESCRIPTION
    Move SSL functions to child process to prevent parent process blocking
    Add debug_printf function and DEBUG_PRINT macro to debug.c file
    Simplify parse_request_line function by using sscanf instead of strtok
    Fix some compiler warnings